### PR TITLE
Updated upgrades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { Nutrients } from "./components/Food/Nutrients";
 import { GameHUD } from "./components/HUD/GameHUD";
 import { ScaleIndicator } from "./components/HUD/ScaleIndicator";
 import { useGame } from "./hooks/useGame";
-import { useMapSelector, useMap } from "./engine/mapState";
+import { useMapSelector } from "./engine/mapState";
 import { useMemo } from "react";
 import Map from "./components/Map/Map";
 
@@ -21,7 +21,6 @@ function App() {
   } = useGame();
 
   const currentLevel = useMapSelector((s) => s.currentLevel);
-  const setLevel = useMap((s) => s.setLevel);
   const phases: (
     | "intro"
     | "microscope"

--- a/src/components/HUD/EvolutionPanel.tsx
+++ b/src/components/HUD/EvolutionPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { GameState } from '../../engine/game';
-import { getCurrentLevel, getNextLevel, canEvolveToNextLevel, evolveToNextLevel } from '../../engine/game';
-import { formatBiomass } from '../../engine/Levels';
+import { getCurrentLevel, getNextLevel, canEvolveToNextLevel } from '../../engine/game';
+import { formatBiomass } from '../../engine/levels';
 
 interface EvolutionPanelProps {
     biomass: number;

--- a/src/components/HUD/Shop.tsx
+++ b/src/components/HUD/Shop.tsx
@@ -21,12 +21,12 @@ export const Shop: React.FC<ShopProps> = ({
   }
 
   const currentLevel = getCurrentLevel(gameState);
-  const currentLevelIndex = LEVELS.findIndex(level => level.id === currentLevel.id);
+  const currentLevelIndex = currentLevel.id;
 
   // Helper function to check if content is available at current level
   const isContentAvailable = (unlockedAtLevel: string) => {
-    const unlockLevelIndex = LEVELS.findIndex(level => level.id === unlockedAtLevel);
-    return unlockLevelIndex <= currentLevelIndex;
+    const unlockLevel = LEVELS.find(level => level.name === unlockedAtLevel);
+    return unlockLevel ? unlockLevel.id <= currentLevelIndex : false;
   };
 
   return (

--- a/src/components/HUD/Shop.tsx
+++ b/src/components/HUD/Shop.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { GameState } from '../../engine/game';
-import { getGeneratorCost } from '../../engine/game';
+import { getGeneratorCost, getCurrentLevel } from '../../engine/game';
+import { LEVELS } from '../../engine/levels';
 
 interface ShopProps {
   biomass: number;
@@ -19,11 +20,22 @@ export const Shop: React.FC<ShopProps> = ({
     return null;
   }
 
+  const currentLevel = getCurrentLevel(gameState);
+  const currentLevelIndex = LEVELS.findIndex(level => level.id === currentLevel.id);
+
+  // Helper function to check if content is available at current level
+  const isContentAvailable = (unlockedAtLevel: string) => {
+    const unlockLevelIndex = LEVELS.findIndex(level => level.id === unlockedAtLevel);
+    return unlockLevelIndex <= currentLevelIndex;
+  };
+
   return (
     <div>
       {/* Generators */}
       <h3 style={{ margin: '0 0 15px 0', fontSize: '16px' }}>Generators</h3>
-      {Object.values(gameState.generators).map(generator => {
+      {Object.values(gameState.generators)
+        .filter(generator => isContentAvailable(generator.unlockedAtLevel))
+        .map(generator => {
         const cost = getGeneratorCost(generator);
         const canAfford = biomass >= cost;
         
@@ -69,7 +81,9 @@ export const Shop: React.FC<ShopProps> = ({
 
       {/* Upgrades */}
       <h3 style={{ margin: '30px 0 15px 0', fontSize: '16px' }}>Upgrades</h3>
-      {Object.values(gameState.upgrades).map(upgrade => {
+      {Object.values(gameState.upgrades)
+        .filter(upgrade => isContentAvailable(upgrade.unlockedAtLevel))
+        .map(upgrade => {
         const canAfford = biomass >= upgrade.cost && !upgrade.purchased;
         
         return (

--- a/src/engine/Levels.ts
+++ b/src/engine/Levels.ts
@@ -4,8 +4,6 @@ export interface Level {
   biomassThreshold: number;
   biomassDisplayFormat: 'standard' | 'scientific' | 'decimal' | 'whole';
   background: string;
-  availableGenerators: string[];
-  availableUpgrades: string[];
   foodTypes: string[];
   description: string;
 }
@@ -14,11 +12,9 @@ export const LEVELS: Level[] = [
   {
     id: 'intro',
     name: 'Intro',
-    biomassThreshold: 1,
+    biomassThreshold: 0,
     biomassDisplayFormat: 'standard',
     background: 'intro-bg',
-    availableGenerators: ['basic-generator'],
-    availableUpgrades: ['click-power'],
     foodTypes: ['nutrients'],
     description: 'Welcome to the beginning of your journey'
   },
@@ -28,8 +24,6 @@ export const LEVELS: Level[] = [
     biomassThreshold: 1e-6, // 0.000001
     biomassDisplayFormat: 'scientific',
     background: 'microscopic-bg',
-    availableGenerators: ['basic-generator', 'farm'],
-    availableUpgrades: ['click-power', 'efficient-generators'],
     foodTypes: ['amoeba', 'bacteria'],
     description: 'You are being observed under a microscope'
   },
@@ -39,8 +33,6 @@ export const LEVELS: Level[] = [
     biomassThreshold: 10,
     biomassDisplayFormat: 'decimal',
     background: 'petri-bg',
-    availableGenerators: ['basic-generator', 'farm', 'factory'],
-    availableUpgrades: ['click-power', 'efficient-generators'],
     foodTypes: ['nutrients', 'organic-matter'],
     description: 'Growing in a petri dish environment'
   },
@@ -50,8 +42,6 @@ export const LEVELS: Level[] = [
     biomassThreshold: 10000000, // 10 million
     biomassDisplayFormat: 'whole',
     background: 'lab-bg',
-    availableGenerators: ['basic-generator', 'farm', 'factory', 'mine'],
-    availableUpgrades: ['click-power', 'efficient-generators'],
     foodTypes: ['chemicals', 'compounds'],
     description: 'The laboratory where experiments are conducted'
   },
@@ -61,8 +51,6 @@ export const LEVELS: Level[] = [
     biomassThreshold: 500000000000, // 500 billion
     biomassDisplayFormat: 'whole',
     background: 'city-bg',
-    availableGenerators: ['basic-generator', 'farm', 'factory', 'mine', 'shipment'],
-    availableUpgrades: ['click-power', 'efficient-generators'],
     foodTypes: ['people', 'vehicles'],
     description: 'A bustling cityscape'
   },
@@ -72,8 +60,6 @@ export const LEVELS: Level[] = [
     biomassThreshold: 1.758e15, // 1.758 quadrillion
     biomassDisplayFormat: 'scientific',
     background: 'earth-bg',
-    availableGenerators: ['basic-generator', 'farm', 'factory', 'mine', 'shipment'],
-    availableUpgrades: ['click-power', 'efficient-generators'],
     foodTypes: ['buildings', 'landmarks'],
     description: 'The entire planet Earth'
   },
@@ -83,8 +69,6 @@ export const LEVELS: Level[] = [
     biomassThreshold: 1e18, // 1 quintillion
     biomassDisplayFormat: 'scientific',
     background: 'solar-system-bg',
-    availableGenerators: ['basic-generator', 'farm', 'factory', 'mine', 'shipment'],
-    availableUpgrades: ['click-power', 'efficient-generators'],
     foodTypes: ['planets', 'asteroids'],
     description: 'The vast solar system'
   }

--- a/src/engine/Levels.ts
+++ b/src/engine/Levels.ts
@@ -1,5 +1,5 @@
 export interface Level {
-  id: string;
+  id: number;
   name: string;
   biomassThreshold: number;
   biomassDisplayFormat: 'standard' | 'scientific' | 'decimal' | 'whole';
@@ -10,8 +10,8 @@ export interface Level {
 
 export const LEVELS: Level[] = [
   {
-    id: 'intro',
-    name: 'Intro',
+    id: 0,
+    name: 'intro',
     biomassThreshold: 0,
     biomassDisplayFormat: 'standard',
     background: 'intro-bg',
@@ -19,8 +19,8 @@ export const LEVELS: Level[] = [
     description: 'Welcome to the beginning of your journey'
   },
   {
-    id: 'microscopic',
-    name: 'Microscopic',
+    id: 1,
+    name: 'microscopic',
     biomassThreshold: 1e-6, // 0.000001
     biomassDisplayFormat: 'scientific',
     background: 'microscopic-bg',
@@ -28,8 +28,8 @@ export const LEVELS: Level[] = [
     description: 'You are being observed under a microscope'
   },
   {
-    id: 'petri-dish',
-    name: 'Petri Dish',
+    id: 2,
+    name: 'petri-dish',
     biomassThreshold: 10,
     biomassDisplayFormat: 'decimal',
     background: 'petri-bg',
@@ -37,8 +37,8 @@ export const LEVELS: Level[] = [
     description: 'Growing in a petri dish environment'
   },
   {
-    id: 'lab',
-    name: 'Laboratory',
+    id: 3,
+    name: 'lab',
     biomassThreshold: 10000000, // 10 million
     biomassDisplayFormat: 'whole',
     background: 'lab-bg',
@@ -46,8 +46,8 @@ export const LEVELS: Level[] = [
     description: 'The laboratory where experiments are conducted'
   },
   {
-    id: 'city',
-    name: 'City',
+    id: 4,
+    name: 'city',
     biomassThreshold: 500000000000, // 500 billion
     biomassDisplayFormat: 'whole',
     background: 'city-bg',
@@ -55,8 +55,8 @@ export const LEVELS: Level[] = [
     description: 'A bustling cityscape'
   },
   {
-    id: 'earth',
-    name: 'Earth',
+    id: 5,
+    name: 'earth',
     biomassThreshold: 1.758e15, // 1.758 quadrillion
     biomassDisplayFormat: 'scientific',
     background: 'earth-bg',
@@ -64,8 +64,8 @@ export const LEVELS: Level[] = [
     description: 'The entire planet Earth'
   },
   {
-    id: 'solar-system',
-    name: 'Solar System',
+    id: 6,
+    name: 'solar-system',
     biomassThreshold: 1e18, // 1 quintillion
     biomassDisplayFormat: 'scientific',
     background: 'solar-system-bg',

--- a/src/engine/content.ts
+++ b/src/engine/content.ts
@@ -1,56 +1,220 @@
 import type { GeneratorState, UpgradeState } from './game';
 
 export const GENERATORS: Record<string, Omit<GeneratorState, 'level'>> = {
+  // Intro Level (1 generator)
   'basic-generator': {
     id: 'basic-generator',
     name: 'Basic Generator',
     baseCost: 15,
     description: 'Generates 0.1 biomass per second',
     baseEffect: 0.1,
-    costMultiplier: 1.15
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'intro'
   },
-  'farm': {
-    id: 'farm',
-    name: 'Farm',
+  'simple-farm': {
+    id: 'simple-farm',
+    name: 'Simple Farm',
     baseCost: 100,
     description: 'Generates 1 biomass per second',
     baseEffect: 1,
-    costMultiplier: 1.15
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'microscopic'
   },
-  'factory': {
-    id: 'factory',
-    name: 'Factory',
+  'starter-lab': {
+    id: 'starter-lab',
+    name: 'Starter Lab',
     baseCost: 1100,
     description: 'Generates 8 biomass per second',
     baseEffect: 8,
-    costMultiplier: 1.15
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'microscopic'
   },
-  'mine': {
-    id: 'mine',
-    name: 'Mine',
+
+  // Microscopic Level (3 new generators)
+  'microscope-cloner': {
+    id: 'microscope-cloner',
+    name: 'Microscope Cloner',
     baseCost: 12000,
-    description: 'Generates 47 biomass per second',
+    description: 'Uses lab-grade optics to split slime particles',
     baseEffect: 47,
-    costMultiplier: 1.15
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'microscopic'
   },
-  'shipment': {
-    id: 'shipment',
-    name: 'Shipment',
+  'cell-divider': {
+    id: 'cell-divider',
+    name: 'Cell Divider',
     baseCost: 130000,
-    description: 'Generates 260 biomass per second',
+    description: 'Forces rapid cellular division through chemical stimulation',
     baseEffect: 260,
-    costMultiplier: 1.15
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'microscopic'
+  },
+  'nucleus-replicator': {
+    id: 'nucleus-replicator',
+    name: 'Nucleus Replicator',
+    baseCost: 1400000,
+    description: 'Duplicates genetic material for exponential growth',
+    baseEffect: 1400,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'microscopic'
+  },
+
+  // Petri Dish Level (3 new generators)
+  'colony-expander': {
+    id: 'colony-expander',
+    name: 'Colony Expander',
+    baseCost: 20000000,
+    description: 'Increases surface area for growth',
+    baseEffect: 7800,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'petri-dish'
+  },
+  'spore-launcher': {
+    id: 'spore-launcher',
+    name: 'Spore Launcher',
+    baseCost: 330000000,
+    description: 'Shoots spores to seed new growth areas',
+    baseEffect: 44000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'petri-dish'
+  },
+  'contaminant-converter': {
+    id: 'contaminant-converter',
+    name: 'Contaminant Converter',
+    baseCost: 5100000000,
+    description: 'Converts waste into growth fuel',
+    baseEffect: 260000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'petri-dish'
+  },
+
+  // Lab Level (3 new generators)
+  'centrifuge-sorter': {
+    id: 'centrifuge-sorter',
+    name: 'Centrifuge Sorter',
+    baseCost: 75000000000,
+    description: 'Isolates the most efficient growth cells',
+    baseEffect: 1600000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'lab'
+  },
+  'bioreactor-tank': {
+    id: 'bioreactor-tank',
+    name: 'Bioreactor Tank',
+    baseCost: 1000000000000,
+    description: 'Massive controlled growth environment',
+    baseEffect: 10000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'lab'
+  },
+  'autoclave-recycler': {
+    id: 'autoclave-recycler',
+    name: 'Autoclave Recycler',
+    baseCost: 14000000000000,
+    description: 'Recycles lab waste into growth fuel',
+    baseEffect: 65000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'lab'
+  },
+
+  // City Level (3 new generators)
+  'humanoid-slimes': {
+    id: 'humanoid-slimes',
+    name: 'Humanoid Slimes',
+    baseCost: 170000000000000,
+    description: 'Shape-shifting growth infiltrators',
+    baseEffect: 430000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'city'
+  },
+  'sewer-colonies': {
+    id: 'sewer-colonies',
+    name: 'Sewer Colonies',
+    baseCost: 2100000000000000,
+    description: 'Hidden mass production underground',
+    baseEffect: 2900000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'city'
+  },
+  'subway-spreaders': {
+    id: 'subway-spreaders',
+    name: 'Subway Spreaders',
+    baseCost: 26000000000000000,
+    description: 'Rapid underground transportation for city-wide growth',
+    baseEffect: 21000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'city'
+  },
+
+  // Earth Level (3 new generators)
+  'cargo-ship-infestors': {
+    id: 'cargo-ship-infestors',
+    name: 'Cargo Ship Infestors',
+    baseCost: 710000000000000000,
+    description: 'Global shipping routes expand potential for growth',
+    baseEffect: 150000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'earth'
+  },
+  'airplane-spore-units': {
+    id: 'airplane-spore-units',
+    name: 'Airplane Spore Units',
+    baseCost: 11000000000000000000,
+    description: 'Airborne routes expand potential for growth',
+    baseEffect: 1100000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'earth'
+  },
+  'forest-hive-colonies': {
+    id: 'forest-hive-colonies',
+    name: 'Forest Hive Colonies',
+    baseCost: 83000000000000000000,
+    description: 'Rural mass production',
+    baseEffect: 8300000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'earth'
+  },
+
+  // Solar System Level (3 new generators)
+  'terraforming-ooze': {
+    id: 'terraforming-ooze',
+    name: 'Terraforming Ooze',
+    baseCost: 640000000000000000000,
+    description: 'Manufactures new planets for growth colonization',
+    baseEffect: 51000000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'solar-system'
+  },
+  'asteroid-seeder': {
+    id: 'asteroid-seeder',
+    name: 'Asteroid Seeder',
+    baseCost: 5100000000000000000000,
+    description: 'Fires growth pods across space',
+    baseEffect: 410000000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'solar-system'
+  },
+  'starship-incubator': {
+    id: 'starship-incubator',
+    name: 'Starship Incubator',
+    baseCost: 71000000000000000000000,
+    description: 'Grows biomass on interstellar ships',
+    baseEffect: 2900000000000000,
+    costMultiplier: 1.15,
+    unlockedAtLevel: 'solar-system'
   }
 };
 
 export const UPGRADES: Record<string, Omit<UpgradeState, 'purchased'>> = {
+  // Intro Level (1 upgrade)
   'click-power': {
     id: 'click-power',
     name: 'Click Power',
     cost: 50,
     description: 'Doubles your click power',
     effect: 1,
-    type: 'click'
+    type: 'click',
+    unlockedAtLevel: 'intro'
   },
   'efficient-generators': {
     id: 'efficient-generators',
@@ -58,7 +222,191 @@ export const UPGRADES: Record<string, Omit<UpgradeState, 'purchased'>> = {
     cost: 500,
     description: 'Each basic generator gives +0.1 biomass/s',
     effect: 0.1,
-    type: 'growth'
+    type: 'growth',
+    unlockedAtLevel: 'microscopic'
+  },
+  'growth-multiplier': {
+    id: 'growth-multiplier',
+    name: 'Growth Multiplier',
+    cost: 5000,
+    description: 'Doubles overall growth rate',
+    effect: 2,
+    type: 'growth',
+    unlockedAtLevel: 'microscopic'
+  },
+
+  // Microscopic Level (3 new upgrades)
+  'enhanced-microscope-optics': {
+    id: 'enhanced-microscope-optics',
+    name: 'Enhanced Microscope Optics',
+    cost: 50000,
+    description: 'Boost generator yield',
+    effect: 0.5,
+    type: 'growth',
+    unlockedAtLevel: 'microscopic'
+  },
+  'sterile-technique-mastery': {
+    id: 'sterile-technique-mastery',
+    name: 'Sterile Technique Mastery',
+    cost: 500000,
+    description: 'Improves all growth rates',
+    effect: 1.5,
+    type: 'growth',
+    unlockedAtLevel: 'microscopic'
+  },
+  'rapid-binary-fission': {
+    id: 'rapid-binary-fission',
+    name: 'Rapid Binary Fission',
+    cost: 5000000,
+    description: 'Doubles overall growth rate',
+    effect: 2,
+    type: 'growth',
+    unlockedAtLevel: 'microscopic'
+  },
+
+  // Petri Dish Level (3 new upgrades)
+  'temperature-control-module': {
+    id: 'temperature-control-module',
+    name: 'Temperature Control Module',
+    cost: 50000000,
+    description: 'Optimal growth rates',
+    effect: 1.5,
+    type: 'growth',
+    unlockedAtLevel: 'petri-dish'
+  },
+  'nutrient-enriched-agar': {
+    id: 'nutrient-enriched-agar',
+    name: 'Nutrient-Enriched Agar',
+    cost: 500000000,
+    description: 'Doubles growth output',
+    effect: 2,
+    type: 'growth',
+    unlockedAtLevel: 'petri-dish'
+  },
+  'antibiotic-resistance': {
+    id: 'antibiotic-resistance',
+    name: 'Antibiotic Resistance',
+    cost: 5000000000,
+    description: 'Improves resistance to parasitic microbes, increasing growth',
+    effect: 1.3,
+    type: 'growth',
+    unlockedAtLevel: 'petri-dish'
+  },
+
+  // Lab Level (3 new upgrades)
+  'lab-assistant-automation': {
+    id: 'lab-assistant-automation',
+    name: 'Lab Assistant Automation',
+    cost: 50000000000,
+    description: 'Brainwash lab workers to improve generator efficiency',
+    effect: 1.4,
+    type: 'growth',
+    unlockedAtLevel: 'lab'
+  },
+  'sterile-workflow': {
+    id: 'sterile-workflow',
+    name: 'Sterile Workflow',
+    cost: 500000000000,
+    description: 'Improves all production by 25%',
+    effect: 1.25,
+    type: 'growth',
+    unlockedAtLevel: 'lab'
+  },
+  'precision-pipetting': {
+    id: 'precision-pipetting',
+    name: 'Precision Pipetting',
+    cost: 5000000000000,
+    description: 'Higher yield per batch',
+    effect: 1.6,
+    type: 'growth',
+    unlockedAtLevel: 'lab'
+  },
+
+  // City Level (3 new upgrades)
+  'mimicry-training': {
+    id: 'mimicry-training',
+    name: 'Mimicry Training',
+    cost: 50000000000000,
+    description: 'Humanoid slimes blend in better, becoming more powerful',
+    effect: 1.7,
+    type: 'growth',
+    unlockedAtLevel: 'city'
+  },
+  'urban-camouflage': {
+    id: 'urban-camouflage',
+    name: 'Urban Camouflage',
+    cost: 500000000000000,
+    description: 'Improves growth efficiency',
+    effect: 1.35,
+    type: 'growth',
+    unlockedAtLevel: 'city'
+  },
+  'subway-expansion-plan': {
+    id: 'subway-expansion-plan',
+    name: 'Subway Expansion Plan',
+    cost: 5000000000000000,
+    description: 'Even faster city-wide growth',
+    effect: 1.8,
+    type: 'growth',
+    unlockedAtLevel: 'city'
+  },
+
+  // Earth Level (3 new upgrades)
+  'intercontinental-mutation': {
+    id: 'intercontinental-mutation',
+    name: 'Intercontinental Mutation',
+    cost: 50000000000000000,
+    description: 'Adapts to all climates for better growth',
+    effect: 1.9,
+    type: 'growth',
+    unlockedAtLevel: 'earth'
+  },
+  'planetary-stealth-mode': {
+    id: 'planetary-stealth-mode',
+    name: 'Planetary Stealth Mode',
+    cost: 500000000000000000,
+    description: 'Slip behind Mother Nature\'s back to improve growth',
+    effect: 1.45,
+    type: 'growth',
+    unlockedAtLevel: 'earth'
+  },
+  'accelerated-core-evolution': {
+    id: 'accelerated-core-evolution',
+    name: 'Accelerated Core Evolution',
+    cost: 5000000000000000000,
+    description: 'Planetary-level output boost',
+    effect: 2.5,
+    type: 'growth',
+    unlockedAtLevel: 'earth'
+  },
+
+  // Solar System Level (3 new upgrades)
+  'cosmic-radiation-tolerance': {
+    id: 'cosmic-radiation-tolerance',
+    name: 'Cosmic Radiation Tolerance',
+    cost: 50000000000000000000,
+    description: 'Survive and multiplies anywhere in the galaxy',
+    effect: 2.1,
+    type: 'growth',
+    unlockedAtLevel: 'solar-system'
+  },
+  'faster-than-light-spread': {
+    id: 'faster-than-light-spread',
+    name: 'Faster-Than-Light Spread',
+    cost: 500000000000000000000,
+    description: 'Instant intergalaxial slime spread',
+    effect: 3,
+    type: 'growth',
+    unlockedAtLevel: 'solar-system'
+  },
+  'self-replicating-probes': {
+    id: 'self-replicating-probes',
+    name: 'Self-Replicating Probes',
+    cost: 5000000000000000000000,
+    description: 'Automated seeding of new established worlds',
+    effect: 2.8,
+    type: 'growth',
+    unlockedAtLevel: 'solar-system'
   }
 };
 

--- a/src/engine/game.test.ts
+++ b/src/engine/game.test.ts
@@ -1,22 +1,57 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { 
-    initialGameState, 
-    manualClick, 
-    tick, 
-    buyGenerator, 
+    INITIAL_STATE,
+    buyGenerator,
     buyUpgrade,
+    manualClick,
+    consumeNutrient,
     getGeneratorCost,
     getTotalGrowth,
-    consumeNutrient,
-    getNearbyNutrients
+    getNearbyNutrients,
+    tick
 } from './game';
 import { GENERATORS, UPGRADES, GAME_CONFIG } from './content';
 
+describe('Game Engine', () => {
+    it('should initialize with correct default values', () => {
+        const gameState = INITIAL_STATE;
+        
+        expect(gameState.biomass).toBe(1);
+        expect(gameState.clickPower).toBe(1);
+        expect(gameState.growth).toBe(0);
+        expect(gameState.currentLevelId).toBe(0);
+        expect(gameState.highestLevelReached).toBe(0);
+    });
+
+    it('should initialize generators with correct default values', () => {
+        const gameState = INITIAL_STATE;
+        
+        Object.values(gameState.generators).forEach((generator: any) => {
+            expect(generator.level).toBe(0);
+        });
+    });
+
+    it('should initialize upgrades with correct default values', () => {
+        const gameState = INITIAL_STATE;
+        
+        Object.values(gameState.upgrades).forEach((upgrade: any) => {
+            expect(upgrade.purchased).toBe(false);
+        });
+    });
+
+    it('should initialize nutrients with correct default values', () => {
+        const gameState = INITIAL_STATE;
+        
+        expect(gameState.nutrients.length).toBeGreaterThan(0);
+        expect(gameState.nutrients.every((n: any) => !n.consumed)).toBe(true);
+    });
+});
+
 describe('Game Logic', () => {
-    let gameState: typeof initialGameState;
+    let gameState: typeof INITIAL_STATE;
 
     beforeEach(() => {
-        gameState = { ...initialGameState };
+        gameState = { ...INITIAL_STATE };
     });
 
     describe('Initial State', () => {

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -42,8 +42,8 @@ export interface GameState {
     generators: Record<string, GeneratorState>
     upgrades: Record<string, UpgradeState>
     nutrients: NutrientState[]
-    currentLevelId: string
-    highestLevelReached: string
+    currentLevelId: number
+    highestLevelReached: number
 }
 
 const initializeGenerators = () => {
@@ -81,7 +81,7 @@ const initializeNutrients = (): NutrientState[] => {
     return nutrients;
 };
 
-export const initialGameState: GameState = {
+export const INITIAL_STATE: GameState = {
     blobs: [],
     biomass: GAME_CONFIG.startingBiomass,
     growth: 0,
@@ -89,8 +89,8 @@ export const initialGameState: GameState = {
     generators: initializeGenerators(),
     upgrades: initializeUpgrades(),
     nutrients: initializeNutrients(),
-    currentLevelId: 'intro',
-    highestLevelReached: 'intro'
+    currentLevelId: 0,
+    highestLevelReached: 0
 }
 
 export function tick(state: GameState): GameState {
@@ -255,7 +255,7 @@ export function spawnMoreNutrients(state: GameState): GameState {
 }
 
 // Helper function to get level by ID
-function getLevelById(levelId: string) {
+function getLevelById(levelId: number) {
     return LEVELS.find(level => level.id === levelId) || LEVELS[0];
 }
 

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -1,5 +1,5 @@
 import { GENERATORS, UPGRADES, GAME_CONFIG } from './content';
-import { getCurrentLevel as getLevelByBiomass, getNextLevel as getNextLevelByCurrent, canEvolve, LEVELS } from './Levels';
+import { getNextLevel as getNextLevelByCurrent, LEVELS } from './levels';
 
 export interface BlobState {
     size: number
@@ -20,6 +20,7 @@ export interface GeneratorState {
     baseEffect: number
     level: number
     costMultiplier: number
+    unlockedAtLevel: string
 }
 
 export interface UpgradeState {
@@ -30,6 +31,7 @@ export interface UpgradeState {
     effect: number
     type: 'growth' | 'split' | 'click' | 'blob'
     purchased: boolean
+    unlockedAtLevel: string
 }
 
 export interface GameState {
@@ -124,21 +126,16 @@ export function buyGenerator(state: GameState, generatorId: string): GameState {
         level: generator.level + 1
     };
 
-    // Calculate total growth from all generators
-    let totalGrowth = 0;
-    Object.values(newGenerators).forEach(gen => {
-        totalGrowth += gen.baseEffect * gen.level;
+    // Calculate total growth with new generator and all upgrades
+    const newGrowth = getTotalGrowth({
+        ...state,
+        generators: newGenerators
     });
-
-    // Apply upgrade effects
-    if (state.upgrades['efficient-generators'].purchased) {
-        totalGrowth += newGenerators['basic-generator'].level * state.upgrades['efficient-generators'].effect;
-    }
 
     return {
         ...state,
         biomass: state.biomass - currentCost,
-        growth: totalGrowth,
+        growth: newGrowth,
         generators: newGenerators
     };
 }
@@ -156,24 +153,17 @@ export function buyUpgrade(state: GameState, upgradeId: string): GameState {
     };
 
     let newClickPower = state.clickPower;
-    let newGrowth = state.growth;
 
     // Apply upgrade effects
     if (upgrade.type === 'click') {
         newClickPower += upgrade.effect;
-    } else if (upgrade.type === 'growth') {
-        // Recalculate growth with new upgrade effect
-        let totalGrowth = 0;
-        Object.values(state.generators).forEach(gen => {
-            totalGrowth += gen.baseEffect * gen.level;
-        });
-
-        if (upgradeId === 'efficient-generators') {
-            totalGrowth += state.generators['basic-generator'].level * upgrade.effect;
-        }
-
-        newGrowth = totalGrowth;
     }
+
+    // Recalculate total growth with all upgrades
+    const newGrowth = getTotalGrowth({
+        ...state,
+        upgrades: newUpgrades
+    });
 
     return {
         ...state,
@@ -195,9 +185,17 @@ export function getTotalGrowth(state: GameState): number {
     });
 
     // Apply upgrade effects
-    if (state.upgrades['efficient-generators'].purchased) {
-        totalGrowth += state.generators['basic-generator'].level * state.upgrades['efficient-generators'].effect;
-    }
+    Object.values(state.upgrades).forEach(upgrade => {
+        if (upgrade.purchased) {
+            if (upgrade.type === 'growth') {
+                // Growth upgrades multiply the total growth
+                totalGrowth *= upgrade.effect;
+            } else if (upgrade.id === 'efficient-generators') {
+                // Special case for efficient generators
+                totalGrowth += state.generators['basic-generator'].level * upgrade.effect;
+            }
+        }
+    });
 
     return totalGrowth;
 }
@@ -215,7 +213,7 @@ export function consumeNutrient(state: GameState, nutrientId: string): GameState
     };
 }
 
-export function getNearbyNutrients(state: GameState, blobPosition: { x: number; y: number }): Array<{ id: string; x: number; y: number; distance: number }> {
+export function getNearbyNutrients(state: GameState, _blobPosition: { x: number; y: number }): Array<{ id: string; x: number; y: number; distance: number }> {
     return state.nutrients
         .filter(n => !n.consumed)
         .map(nutrient => {

--- a/src/engine/mapState.ts
+++ b/src/engine/mapState.ts
@@ -1,7 +1,7 @@
 import { immer } from 'zustand/middleware/immer'
 import { create } from 'zustand'
-import type { Level } from './Levels'
-import { getCurrentLevel } from './Levels'
+import type { Level } from './levels'
+import { getCurrentLevel } from './levels'
 
 export type CellStatus = 'empty' | 'nutrient' | 'blob'
 
@@ -49,7 +49,7 @@ export const useMap = create<MapState>()(
                     s.currentLevel = level
                 }),
             evolveToNextLevel: () =>
-                set(s => {
+                set(_s => {
                     // This will be implemented to handle level transitions
                     // For now, just a placeholder
                 }),

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -36,7 +36,7 @@ export const useGame = () => {
     setGameState(prevState => buyUpgrade(prevState, upgradeId));
   }, []);
 
-  const handleNutrientEaten = useCallback((blobId: string, nutrientId: string) => {
+  const handleNutrientEaten = useCallback((_blobId: string, nutrientId: string) => {
     setGameState(prevState => consumeNutrient(prevState, nutrientId));
   }, []);
 

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { 
-  initialGameState, 
+  INITIAL_STATE, 
   tick, 
   manualClick, 
   buyGenerator, 
@@ -13,7 +13,7 @@ import {
 import { GAME_CONFIG } from '../engine/content';
 
 export const useGame = () => {
-  const [gameState, setGameState] = useState<GameState>(initialGameState);
+  const [gameState, setGameState] = useState<GameState>(INITIAL_STATE);
 
   // Game loop
   useEffect(() => {


### PR DESCRIPTION
Commit 3340a74
- Add unlockedAtLevel property to generators and upgrades
- Update shop to filter content based on current level
- Simplify Levels data structure by removing explicit content arrays
- Fix import casing issues by consolidating to lowercase levels.ts
- Ensure players retain access to all previously unlocked content
- Update game logic to properly handle level progression

Commit 7db09d2
- Change level id from string to number (0-6) for easier comparisons
- Keep unlockedAtLevel as strings referencing level names for readability
- Update Shop component to use numeric level filtering
- Update game state to use numeric level tracking
- Fix test file imports and type issues
- Maintain hybrid approach: numeric IDs for performance, string names for readability