### PR TITLE
Map generators, shop scroll, value scale, compact number format

### DIFF
--- a/src/components/animations/FloatingNumber.tsx
+++ b/src/components/animations/FloatingNumber.tsx
@@ -71,7 +71,7 @@ export const FloatingNumber: React.FC<FloatingNumberProps> = ({
         zIndex: 1000
       }}
     >
-      {NumberFormatter.rate(value)}
+      +{NumberFormatter.compact(value)}
     </div>
   );
 };

--- a/src/components/hud/Evolution/EvolutionPanel.tsx
+++ b/src/components/hud/Evolution/EvolutionPanel.tsx
@@ -38,7 +38,7 @@ export const EvolutionPanel: React.FC<EvolutionPanelProps> = ({
         right: 0,
         width: "300px",
         height: "100vh",
-        backgroundColor: "rgba(0, 0, 0, 0.8)",
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
         color: "white",
         fontFamily: "Arial, sans-serif",
         padding: "20px",

--- a/src/components/hud/GameHUD.tsx
+++ b/src/components/hud/GameHUD.tsx
@@ -37,6 +37,12 @@ export const GameHUD: React.FC<GameHUDProps> = ({
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
+          color: 'white',
+          padding: '20px',
+          borderRadius: '10px',
+          fontFamily: 'Arial, sans-serif',
+          fontSize: '14px',
+          minWidth: '200px'
         }}
       >
         <GameStats biomass={biomass} gameState={gameState} />

--- a/src/components/hud/GameStats.tsx
+++ b/src/components/hud/GameStats.tsx
@@ -22,7 +22,7 @@ export const GameStats: React.FC<GameStatsProps> = ({ biomass, gameState }) => {
       justifyContent: 'center',
       width: 'fit-content',
       minWidth: '100px',
-      backgroundColor: 'rgba(0, 0, 0, 0.8)',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
       padding: `20px ${horizontalPadding}px`,
       borderRadius: '0 0 18px 18px',
       color: 'white',

--- a/src/components/hud/Shop/Generators.tsx
+++ b/src/components/hud/Shop/Generators.tsx
@@ -34,10 +34,6 @@ export const Generators: React.FC<GeneratorsProps> = ({
             return isContentAvailable(generator.unlockedAtLevel, currentLevel.name);
           }
         })
-        .sort((a, b) => {
-          // Sort by cost
-          return a.baseCost - b.baseCost;
-        })
         .map(generator => {
         const singleCost = generator.baseCost * Math.pow(generator.costMultiplier, generator.level);
         const totalCost = calculateTotalCost(generator, buyMultiplier);

--- a/src/components/hud/Shop/ValueScale.tsx
+++ b/src/components/hud/Shop/ValueScale.tsx
@@ -27,7 +27,7 @@ export const ValueScale: React.FC<ValueScaleProps> = ({ gameState, highThreshold
         color: '#fff'
       }}>Value:</span>
       
-      {/* High Value (Green) */}
+      {/* Best Value (Green) */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
@@ -50,7 +50,7 @@ export const ValueScale: React.FC<ValueScaleProps> = ({ gameState, highThreshold
           fontSize: '12px',
           textShadow: '0 1px 2px rgba(0, 0, 0, 0.5)'
         }}>
-          {NumberFormatter.compact(highThreshold)}+
+          {NumberFormatter.compact(lowThreshold)}-
         </span>
       </div>
       
@@ -81,7 +81,7 @@ export const ValueScale: React.FC<ValueScaleProps> = ({ gameState, highThreshold
         </span>
       </div>
       
-      {/* Low Value (Red) */}
+      {/* Worst Value (Red) */}
       <div style={{
         display: 'flex',
         alignItems: 'center',
@@ -104,7 +104,7 @@ export const ValueScale: React.FC<ValueScaleProps> = ({ gameState, highThreshold
           fontSize: '12px',
           textShadow: '0 1px 2px rgba(0, 0, 0, 0.5)'
         }}>
-          {NumberFormatter.compact(lowThreshold)}-
+          {NumberFormatter.compact(highThreshold)}+
         </span>
       </div>
     </div>

--- a/src/components/map/MapGenerators.tsx
+++ b/src/components/map/MapGenerators.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useEffect, useRef, useState } from "react";
 import type { GameState } from "../../game/types";
 import { GAME_CONFIG } from "../../game/content/config";
+import { GENERATORS } from "../../game/content/generators";
 import { useMapSelector } from "../../game/systems/mapState";
 import {
   calculateGeneratorGroups,
@@ -79,42 +80,116 @@ export const MapGenerators: React.FC<GeneratorVisualizationProps> = ({
     return () => clearInterval(interval);
   }, [generators, gameState, blobSize, addFloatingNumber]);
 
-  if (generators.length === 0) {
+  if (generators.length === 0 && Object.keys(generatorGroups.previousLevels).length === 0) {
     return null;
   }
 
   const { display } = GAME_CONFIG.generatorVisualization;
   const blobPosition = calculateBlobPosition();
 
-  return (
-    <div className="fixed inset-0 pointer-events-none z-50">
-      {generators.map((generator) => {
-        const x = blobPosition.x + generator.position.x;
-        const y = blobPosition.y + generator.position.y;
+  // Render current level generators
+  const currentLevelGenerators = generators.map((generator) => {
+    const x = blobPosition.x + generator.position.x;
+    const y = blobPosition.y + generator.position.y;
 
-        return (
+    return (
+      <div
+        key={generator.id}
+        className="absolute"
+        style={{
+          left: x,
+          top: y,
+          transform: "translate(-50%, -50%)",
+          fontSize: `${display.currentLevelSize}px`,
+          lineHeight: 1,
+          pointerEvents: "auto",
+          userSelect: "none",
+          color: "#000",
+          textShadow: "0 0 2px rgba(255, 255, 255, 0.8)",
+          zIndex: 60,
+          cursor: "help",
+        }}
+        title={`${generator.emoji} (${generator.count} owned)`}
+      >
+        {generator.emoji}
+      </div>
+    );
+  });
+
+  // Render stacked previous level generators
+  const stackedGenerators = Object.entries(generatorGroups.previousLevels).map(([levelId, levelGenerators]) => {
+    if (levelGenerators.length === 0) return null;
+
+    // Calculate total count and effect for this level
+    const totalCount = levelGenerators.reduce((sum, gen) => sum + gen.level, 0);
+    
+    // Get emoji from first generator in the level
+    const firstGenerator = GENERATORS[levelGenerators[0].id];
+    const emoji = firstGenerator?.name.split(" ")[0] || "⚪";
+
+    // Random position for stacked generator
+    const angle = Math.random() * 2 * Math.PI;
+    const distance = (blobSize * 0.35 - GAME_CONFIG.generatorVisualization.movement.padding) * Math.random();
+    const x = blobPosition.x + Math.cos(angle) * distance;
+    const y = blobPosition.y + Math.sin(angle) * distance;
+
+    return (
+      <div
+        key={`stacked-${levelId}`}
+        className="absolute"
+        style={{
+          left: x,
+          top: y,
+          transform: "translate(-50%, -50%)",
+          fontSize: `${display.stackedLevelSize}px`,
+          lineHeight: 1,
+          pointerEvents: "auto",
+          userSelect: "none",
+          color: "#000",
+          textShadow: "0 0 2px rgba(255, 255, 255, 0.8)",
+          zIndex: 55,
+          cursor: "help",
+        }}
+        title={`${emoji} (${totalCount} total from previous levels)`}
+      >
+        <div style={{ position: 'relative' }}>
+          {emoji}
           <div
-            key={generator.id}
-            className="absolute"
             style={{
-              left: x,
-              top: y,
-              transform: "translate(-50%, -50%)",
-              fontSize: `${display.currentLevelSize}px`,
+              position: 'absolute',
+              top: '-8px',
+              right: '-8px',
+              fontSize: `${display.countOverlaySize}px`,
+              backgroundColor: 'rgba(0, 0, 0, 0.8)',
+              color: 'white',
+              borderRadius: '50%',
+              width: '16px',
+              height: '16px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
               lineHeight: 1,
-              pointerEvents: "auto",
-              userSelect: "none",
-              color: "#000",
-              textShadow: "0 0 2px rgba(255, 255, 255, 0.8)",
-              zIndex: 60,
-              cursor: "help",
             }}
-            title={`${generator.emoji} (${generator.count} owned)`}
           >
-            {generator.emoji}
+            {totalCount}
           </div>
-        );
-      })}
+        </div>
+      </div>
+    );
+  });
+
+  return (
+    <div style={{ 
+      position: 'absolute', 
+      top: 0, 
+      left: 0, 
+      width: '100%', 
+      height: '100%', 
+      pointerEvents: 'none',
+      zIndex: 50
+    }}>
+      {currentLevelGenerators}
+      {stackedGenerators}
     </div>
   );
 };

--- a/src/game/systems/actions.ts
+++ b/src/game/systems/actions.ts
@@ -146,4 +146,12 @@ export function calculateTotalCost(generator: any, count: number): number {
     totalCost += cost;
   }
   return totalCost;
+}
+
+// Get all generators unlocked through the current level
+export function getUnlockedGenerators(gameState: GameState): any[] {
+  const currentLevel = getCurrentLevel(gameState);
+  return Object.values(gameState.generators).filter(generator => 
+    isContentAvailable(generator.unlockedAtLevel, currentLevel.name)
+  );
 } 

--- a/src/game/systems/actions.ts
+++ b/src/game/systems/actions.ts
@@ -137,15 +137,15 @@ export function isContentAvailable(unlockedAtLevel: string, currentLevelName: st
   return levelIndex <= currentLevelIndex;
 }
 
-// Calculate total cost for buying multiple generators
-export function calculateTotalCost(generator: any, count: number): number {
-  let totalCost = 0;
-  for (let i = 0; i < count; i++) {
-    const currentLevel = generator.level + i;
-    const cost = generator.baseCost * Math.pow(generator.costMultiplier, currentLevel);
-    totalCost += cost;
-  }
-  return totalCost;
+// Calculate total cost for buying multiple generators (from incoming branch)
+export function calculateTotalCost(generator: { baseCost: number; costMultiplier: number; level: number }, count: number): number {
+    let totalCost = 0;
+    for (let i = 0; i < count; i++) {
+        const currentLevel = generator.level + i;
+        const cost = generator.baseCost * Math.pow(generator.costMultiplier, currentLevel);
+        totalCost += cost;
+    }
+    return totalCost;
 }
 
 // Get all generators unlocked through the current level

--- a/src/game/systems/generatorValue.ts
+++ b/src/game/systems/generatorValue.ts
@@ -1,5 +1,6 @@
 import type { GameState, GeneratorState } from '../types';
 import type { GeneratorValue } from '../types';
+import { getUnlockedGenerators } from './actions';
 
 // Calculate the value of purchasing the next level of a generator: Value = (cost of next generator) / (increase in growth)
 // Lower values are better (cheaper per unit of growth)
@@ -56,14 +57,14 @@ export function calculateAllGeneratorValues(gameState: GameState): GeneratorValu
         const normalizedValue = (item.value - minValue) / valueRange;
         
         if (normalizedValue <= 0.33) {
-          // Lowest third: green (best value)
-          item.color = '#22c55e';
+          // Lowest third: red (worst value - highest cost/growth)
+          item.color = '#ef4444';
         } else if (normalizedValue <= 0.66) {
-        // Middle third: yellow
-        item.color = '#f59e0b';
-      } else {
-          // Highest third: red (worst value)
-        item.color = '#ef4444';
+          // Middle third: yellow
+          item.color = '#f59e0b';
+        } else {
+          // Highest third: green (best value - lowest cost/growth)
+          item.color = '#22c55e';
         }
       }
     }
@@ -79,6 +80,58 @@ export function getGeneratorValueInfo(
   generatorId: string, 
   gameState: GameState
 ): GeneratorValue | null {
-  const allValues = calculateAllGeneratorValues(gameState);
-  return allValues.find(v => v.generatorId === generatorId) || null;
+  // Get all unlocked generators through current level
+  const unlockedGenerators = getUnlockedGenerators(gameState);
+  
+  const values: GeneratorValue[] = [];
+  
+  unlockedGenerators.forEach(generator => {
+    const value = calculateGeneratorValue(generator);
+    values.push({
+      generatorId: generator.id,
+      value,
+      color: '', // Will be set after sorting
+      rank: 0 // Will be set after sorting
+    });
+  });
+  
+  // Don't sort - keep generators in their original order
+  // values.sort((a, b) => a.value - b.value);
+  
+  // Assign colors and ranks based on value ranges
+  values.forEach((item, index) => {
+    item.rank = index + 1;
+    
+    if (values.length === 1) {
+      // Only one generator, make it green
+      item.color = '#22c55e';
+    } else {
+      // Find min and max values for color assignment
+      const allValues = values.map(v => v.value).filter(v => v !== Infinity);
+      const minValue = Math.min(...allValues);
+      const maxValue = Math.max(...allValues);
+      const valueRange = maxValue - minValue;
+      
+      if (valueRange === 0) {
+        // All values are the same
+        item.color = '#22c55e';
+      } else {
+        // Normalize value to 0-1 range
+        const normalizedValue = (item.value - minValue) / valueRange;
+        
+        if (normalizedValue <= 0.33) {
+          // Lowest third: green (best value - lowest cost/growth)
+          item.color = '#22c55e';
+        } else if (normalizedValue <= 0.66) {
+          // Middle third: yellow
+          item.color = '#f59e0b';
+        } else {
+          // Highest third: red (worst value - highest cost/growth)
+          item.color = '#ef4444';
+        }
+      }
+    }
+  });
+  
+  return values.find(v => v.generatorId === generatorId) || null;
 } 

--- a/src/game/systems/generatorVisualization.ts
+++ b/src/game/systems/generatorVisualization.ts
@@ -140,8 +140,8 @@ export function calculateFloatingNumbers(
   const totalGrowth = getTotalGrowth(gameState);
 
   generators.forEach((generator) => {
-    // Check if it's time for a floating number (every 1 second)
-    if (currentTime - generator.lastFloatingNumber >= 1000) {
+    // Check if it's time for a floating number (every 3 seconds)
+    if (currentTime - generator.lastFloatingNumber >= 3000) {
       const contributionRatio = generator.totalEffect / totalGrowth;
       
       let color = colors.highContribution; // Default green


### PR DESCRIPTION
Fix value scale and generator visualization 
Fix value scale colors: lower values now show as green (better deals), higher values as red (worse deals) 
Use all unlocked generators for value scale comparison instead of just current level 
Remove duplicate GameStats background, keep dynamic one 
Reduce panel opacity by 25% for better visibility 
Fix shop scrolling: header stays fixed while content scrolls 
Remove generator sorting to maintain unlock order 
Fix MapGenerators positioning and reduce floating number frequency
Update floating numbers to use compact format with '+' prefix