### PR TITLE
UI improve: shop panel width, tutorial text, slime trail, and styling

### DIFF
--- a/src/components/hud/GameHUD.tsx
+++ b/src/components/hud/GameHUD.tsx
@@ -4,6 +4,7 @@ import { GameStats } from "./GameStats";
 import { Shop } from "./Shop";
 import { EvolutionPanel } from "./Evolution/EvolutionPanel";
 import { TutorialManager } from "../tutorial/TutorialManager";
+import { SlimeTrail } from "../particles/SlimeTrail";
 import { calculateBlobPosition } from "../../game/systems/calculations";
 
 export const GameHUD: React.FC<GameHUDProps> = ({
@@ -16,7 +17,7 @@ export const GameHUD: React.FC<GameHUDProps> = ({
   onTutorialStepComplete,
 }) => {
   const blobPosition = calculateBlobPosition();
-  const shopWidth = 300;
+  const shopWidth = 350;
   const evolutionWidth = 300;
 
   return (
@@ -68,6 +69,9 @@ export const GameHUD: React.FC<GameHUDProps> = ({
           width={evolutionWidth}
         />
       )}
+
+      {/* Slime Trail - Only active when tutorial is not active */}
+      <SlimeTrail isActive={!tutorialState?.isActive} />
 
       {/* Tutorial System - Highest z-index */}
       {tutorialState &&

--- a/src/components/hud/Shop/Shop.tsx
+++ b/src/components/hud/Shop/Shop.tsx
@@ -68,7 +68,7 @@ export const Shop: React.FC<ShopProps> = ({
       >
         <h2
           style={{
-            margin: "0 0 20px 0",
+            margin: "0 0 10px 0",
             fontSize: "24px",
             color: Colors.shop.primary,
             textAlign: "center",
@@ -87,7 +87,6 @@ export const Shop: React.FC<ShopProps> = ({
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
-            marginBottom: "15px",
             gap: "10px",
           }}
         >
@@ -107,7 +106,7 @@ export const Shop: React.FC<ShopProps> = ({
         style={{
           flex: 1,
           overflowY: "auto",
-          padding: "0 20px 20px 20px",
+          padding: "5px 20px 20px 20px",
         }}
       >
         {/* Generators Component */}

--- a/src/components/hud/Shop/ShopGenerators.tsx
+++ b/src/components/hud/Shop/ShopGenerators.tsx
@@ -240,19 +240,17 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
             onMouseEnter={(e) => {
               e.currentTarget.style.transform = "scale(1.01)";
               if (isTutorialPurchased) {
-                e.currentTarget.style.backgroundColor = `${Colors.generators.light}40`;
+                e.currentTarget.style.borderColor = Colors.generators.light;
                 e.currentTarget.style.boxShadow = `0 4px 12px ${Colors.generators.light}60`;
               } else if (
                 canAfford &&
                 (generator.id !== "tutorial-generator" || isTutorialEnabled)
               ) {
-                e.currentTarget.style.backgroundColor = `${Colors.generators.primary}40`;
+                e.currentTarget.style.borderColor = Colors.generators.primary;
                 e.currentTarget.style.boxShadow = `0 4px 12px ${Colors.generators.primary}60`;
               } else {
-                e.currentTarget.style.backgroundColor =
-                  "rgba(255, 255, 255, 0.15)";
-                e.currentTarget.style.boxShadow =
-                  "0 4px 12px rgba(255, 255, 255, 0.1)";
+                e.currentTarget.style.borderColor = "#999";
+                e.currentTarget.style.boxShadow = "0 4px 12px rgba(255, 255, 255, 0.1)";
               }
               // Show stats on hover
               const statsElement = e.currentTarget.querySelector(
@@ -265,15 +263,15 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
             onMouseLeave={(e) => {
               e.currentTarget.style.transform = "scale(1)";
               if (isTutorialPurchased) {
-                e.currentTarget.style.backgroundColor = `${Colors.generators.light}30`;
+                e.currentTarget.style.borderColor = Colors.generators.light;
                 e.currentTarget.style.boxShadow = `0 2px 8px ${Colors.generators.light}40`;
               } else {
-                e.currentTarget.style.backgroundColor =
+                e.currentTarget.style.borderColor =
                   generator.id === "tutorial-generator" && !isTutorialEnabled
-                    ? "rgba(128, 128, 128, 0.3)"
+                    ? "#666"
                     : canAfford
-                    ? `${Colors.generators.primary}30`
-                    : "rgba(255, 255, 255, 0.1)";
+                    ? Colors.generators.primary
+                    : "#666";
                 e.currentTarget.style.boxShadow =
                   generator.id === "tutorial-generator" && !isTutorialEnabled
                     ? "none"
@@ -407,7 +405,7 @@ export const ShopGenerators: React.FC<GeneratorsProps> = ({
                 style={{
                   color: canAfford
                     ? Colors.biomass.primary
-                    : Colors.headlines.primary,
+                    : Colors.headlines.medium,
                   fontWeight: "bold",
                   fontSize: "13px",
                 }}

--- a/src/components/hud/Shop/ShopUpgrades.tsx
+++ b/src/components/hud/Shop/ShopUpgrades.tsx
@@ -119,13 +119,13 @@ export const ShopUpgrades: React.FC<UpgradesProps> = ({
             <div
               key={upgrade.id}
               style={{
-                background: upgrade.purchased
-                  ? `${Colors.upgrades.light}30` // light upgrade color for purchased tutorial upgrade
-                  : upgrade.id === "tutorial-upgrade" && !isTutorialEnabled
-                  ? "rgba(128, 128, 128, 0.3)" // gray for disabled tutorial upgrade
-                  : canAfford
-                  ? `${Colors.upgrades.primary}30`
-                  : "rgba(255, 255, 255, 0.1)",
+                background: upgrade.id === "tutorial-upgrade"
+                  ? upgrade.purchased
+                    ? "rgba(128, 128, 128, 0.3)" // gray background for purchased tutorial upgrade
+                    : tutorialState?.currentStep?.type === "click-blob"
+                    ? "rgba(128, 128, 128, 0.3)" // gray background during click-blob phase
+                    : `${Colors.upgrades.primary}30` // purple background for unpurchased tutorial upgrade
+                  : "rgba(128, 128, 128, 0.2)", // Consistent gray background for other upgrades
                 border: `2px solid ${
                   upgrade.purchased
                     ? Colors.upgrades.light // purple border for purchased tutorial upgrade
@@ -188,40 +188,65 @@ export const ShopUpgrades: React.FC<UpgradesProps> = ({
               onMouseEnter={(e) => {
                 e.currentTarget.style.transform = "scale(1.01)";
                 if (upgrade.purchased) {
-                  e.currentTarget.style.backgroundColor = `${Colors.upgrades.light}40`;
+                  e.currentTarget.style.borderColor = Colors.upgrades.light;
                   e.currentTarget.style.boxShadow = `0 4px 12px ${Colors.upgrades.light}60`;
+                  if (upgrade.id === "tutorial-upgrade") {
+                    e.currentTarget.style.backgroundColor = "rgba(128, 128, 128, 0.4)";
+                  }
                 } else if (
                   canAfford &&
                   !upgrade.purchased &&
                   (upgrade.id !== "tutorial-upgrade" || isTutorialEnabled)
                 ) {
-                  e.currentTarget.style.backgroundColor = `${Colors.upgrades.primary}40`;
+                  e.currentTarget.style.borderColor = Colors.upgrades.primary;
                   e.currentTarget.style.boxShadow = `0 4px 12px ${Colors.upgrades.primary}60`;
+                  if (upgrade.id === "tutorial-upgrade") {
+                    if (tutorialState?.currentStep?.type === "click-blob") {
+                      e.currentTarget.style.backgroundColor = "rgba(128, 128, 128, 0.4)";
+                    } else {
+                      e.currentTarget.style.backgroundColor = `${Colors.upgrades.primary}40`;
+                    }
+                  }
                 } else if (!upgrade.purchased) {
-                  e.currentTarget.style.backgroundColor =
-                    "rgba(255, 255, 255, 0.15)";
-                  e.currentTarget.style.boxShadow =
-                    "0 4px 12px rgba(255, 255, 255, 0.1)";
+                  e.currentTarget.style.borderColor = "#999";
+                  e.currentTarget.style.boxShadow = "0 4px 12px rgba(255, 255, 255, 0.1)";
+                  if (upgrade.id === "tutorial-upgrade") {
+                    if (tutorialState?.currentStep?.type === "click-blob") {
+                      e.currentTarget.style.backgroundColor = "rgba(128, 128, 128, 0.4)";
+                    } else {
+                      e.currentTarget.style.backgroundColor = `${Colors.upgrades.primary}20`;
+                    }
+                  }
                 }
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.transform = "scale(1)";
                 if (upgrade.purchased) {
-                  e.currentTarget.style.backgroundColor = `${Colors.upgrades.light}30`;
+                  e.currentTarget.style.borderColor = Colors.upgrades.light;
                   e.currentTarget.style.boxShadow = `0 2px 8px ${Colors.upgrades.light}40`;
+                  if (upgrade.id === "tutorial-upgrade") {
+                    e.currentTarget.style.backgroundColor = "rgba(128, 128, 128, 0.3)";
+                  }
                 } else if (!upgrade.purchased) {
-                  e.currentTarget.style.backgroundColor =
+                  e.currentTarget.style.borderColor =
                     upgrade.id === "tutorial-upgrade" && !isTutorialEnabled
-                      ? "rgba(128, 128, 128, 0.3)"
+                      ? "#666"
                       : canAfford
-                      ? `${Colors.upgrades.primary}30`
-                      : "rgba(255, 255, 255, 0.1)";
+                      ? Colors.upgrades.primary
+                      : "#666";
                   e.currentTarget.style.boxShadow =
                     upgrade.id === "tutorial-upgrade" && !isTutorialEnabled
                       ? "none"
                       : canAfford
                       ? `0 2px 8px ${Colors.upgrades.primary}40`
                       : "none";
+                  if (upgrade.id === "tutorial-upgrade") {
+                    if (tutorialState?.currentStep?.type === "click-blob") {
+                      e.currentTarget.style.backgroundColor = "rgba(128, 128, 128, 0.3)";
+                    } else {
+                      e.currentTarget.style.backgroundColor = `${Colors.upgrades.primary}30`;
+                    }
+                  }
                 }
               }}
             >
@@ -264,7 +289,7 @@ export const ShopUpgrades: React.FC<UpgradesProps> = ({
                   style={{
                     color: canAfford
                       ? Colors.biomass.primary
-                      : Colors.headlines.primary,
+                      : Colors.headlines.medium,
                     fontWeight: "bold",
                     fontSize: "13px",
                   }}

--- a/src/components/particles/SlimeTrail.tsx
+++ b/src/components/particles/SlimeTrail.tsx
@@ -16,7 +16,6 @@ interface SlimeTrailProps {
 
 export const SlimeTrail: React.FC<SlimeTrailProps> = ({ isActive }) => {
   const [slimeDrops, setSlimeDrops] = useState<SlimeDrop[]>([]);
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const lastDropTime = useRef(0);
   const dropInterval = 25; // Drop every 25ms (50% more frequent)
 
@@ -26,7 +25,6 @@ export const SlimeTrail: React.FC<SlimeTrailProps> = ({ isActive }) => {
 
     const handleMouseMove = (event: MouseEvent) => {
       const newPosition = { x: event.clientX, y: event.clientY };
-      setMousePosition(newPosition);
 
       // Create new slime drop at intervals
       const now = Date.now();

--- a/src/components/particles/SlimeTrail.tsx
+++ b/src/components/particles/SlimeTrail.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Colors } from '../../styles/colors';
+
+interface SlimeDrop {
+  id: string;
+  x: number;
+  y: number;
+  opacity: number;
+  scale: number;
+  createdAt: number;
+}
+
+interface SlimeTrailProps {
+  isActive: boolean;
+}
+
+export const SlimeTrail: React.FC<SlimeTrailProps> = ({ isActive }) => {
+  const [slimeDrops, setSlimeDrops] = useState<SlimeDrop[]>([]);
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const lastDropTime = useRef(0);
+  const dropInterval = 25; // Drop every 25ms (50% more frequent)
+
+  // Track mouse position
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const newPosition = { x: event.clientX, y: event.clientY };
+      setMousePosition(newPosition);
+
+      // Create new slime drop at intervals
+      const now = Date.now();
+      if (now - lastDropTime.current > dropInterval) {
+        const newDrop: SlimeDrop = {
+          id: Math.random().toString(36).substr(2, 9),
+          x: newPosition.x,
+          y: newPosition.y,
+          opacity: 0.8,
+          scale: 1,
+          createdAt: now,
+        };
+
+        setSlimeDrops(prev => [...prev, newDrop]);
+        lastDropTime.current = now;
+      }
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, [isActive]);
+
+  // Clean up old slime drops
+  useEffect(() => {
+    if (!isActive) {
+      setSlimeDrops([]);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      const now = Date.now();
+      setSlimeDrops(prev => 
+        prev.filter(drop => {
+          const age = now - drop.createdAt;
+          return age < 1500; // Keep drops for 1.5 seconds (reduced from 2 seconds)
+        })
+      );
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, [isActive]);
+
+  if (!isActive) return null;
+
+  return (
+    <>
+      {slimeDrops.map((drop) => {
+        const age = Date.now() - drop.createdAt;
+        const progress = age / 1500; // 1.5 second lifetime
+        const opacity = 0.8 * (1 - progress);
+        const scale = 1 - (progress * 0.3);
+
+        return (
+          <div
+            key={drop.id}
+            style={{
+              position: 'fixed',
+              left: drop.x,
+              top: drop.y,
+              transform: `translate(-50%, -50%) scale(${scale})`,
+              width: '8px',
+              height: '8px',
+              backgroundColor: Colors.biomass.primary,
+              borderRadius: '50%',
+              opacity: opacity,
+              pointerEvents: 'none',
+              zIndex: 1000,
+              filter: 'blur(1px)',
+              boxShadow: `0 0 4px ${Colors.biomass.primary}80`,
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}; 

--- a/src/components/tutorial/TutorialManager.tsx
+++ b/src/components/tutorial/TutorialManager.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import type { TutorialState } from '../../game/types/ui';
 import { TutorialArrow } from './TutorialArrow';
 import { ClickIndicator } from './ClickIndicator';
 import { TutorialPopup } from './TutorialPopup';
 import { getCurrentTutorialStep } from '../../game/systems/tutorial';
+import { Colors } from '../../styles/colors';
 
 interface TutorialManagerProps {
   tutorialState: TutorialState;
@@ -17,6 +18,17 @@ export const TutorialManager: React.FC<TutorialManagerProps> = ({
   onTutorialStepComplete,
 }) => {
   const currentStep = getCurrentTutorialStep(tutorialState);
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+
+  // Track mouse position
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      setMousePosition({ x: event.clientX, y: event.clientY });
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, []);
 
   // Only show tutorial if it's active
   if (!tutorialState.isActive || !currentStep) {
@@ -34,17 +46,41 @@ export const TutorialManager: React.FC<TutorialManagerProps> = ({
       {/* Click blob tutorial */}
       {currentStep.type === 'click-blob' && (
         <>
-      <TutorialArrow
-        targetPosition={blobPosition}
-        isVisible={true}
-      />
-      <ClickIndicator
-        position={{
-          x: blobPosition.x,
+          <TutorialArrow
+            targetPosition={blobPosition}
+            isVisible={true}
+          />
+          <ClickIndicator
+            position={{
+              x: blobPosition.x,
               y: blobPosition.y + 130
-        }}
-        isVisible={true}
-      />
+            }}
+            isVisible={true}
+          />
+          {/* Tutorial text under mouse cursor */}
+          <div
+            style={{
+              position: 'fixed',
+              left: mousePosition.x,
+              top: mousePosition.y + 20,
+              transform: 'translateX(-50%)',
+              fontSize: '18px',
+              color: Colors.biomass.dark,
+              textAlign: 'center',
+              textTransform: 'uppercase',
+              textShadow: '0 0 8px rgba(0, 0, 0, 0.8), 0 0 16px rgba(0, 0, 0, 0.8), 0 0 24px rgba(22, 163, 74, 0.6)',
+              fontFamily: 'Arial, sans-serif',
+              fontWeight: 'bold',
+              pointerEvents: 'none',
+              zIndex: 10000,
+              backgroundColor: 'rgba(0, 0, 0, 0.7)',
+              padding: '4px 12px',
+              borderRadius: '6px',
+              border: `2px solid ${Colors.biomass.dark}`,
+            }}
+          >
+            TUTORIAL
+          </div>
         </>
       )}
 

--- a/src/components/tutorial/TutorialPopup.tsx
+++ b/src/components/tutorial/TutorialPopup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Colors } from "../../styles/colors";
 
 interface TutorialPopupProps {
@@ -14,14 +14,6 @@ export const TutorialPopup: React.FC<TutorialPopupProps> = ({
   isVisible,
   onClose,
 }) => {
-  const [isAnimating, setIsAnimating] = useState(false);
-
-  useEffect(() => {
-    if (isVisible) {
-      setIsAnimating(true);
-    }
-  }, [isVisible]);
-
   if (!isVisible) return null;
 
   // Position the popup based on the target area
@@ -39,16 +31,13 @@ export const TutorialPopup: React.FC<TutorialPopupProps> = ({
       cursor: onClose ? "pointer" : "default",
       transition: "all 0.3s ease-in-out",
       fontFamily: "Arial, sans-serif",
-      animation: isAnimating
-        ? "popupExpand 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275)"
-        : "none",
     };
 
     if (position === "shop") {
       return {
         ...baseStyle,
-        left: "320px", // Position next to shop panel (shop is 300px wide + 20px padding)
-        top: "40%",
+        left: "370px", // Moved further right (was 320px)
+        top: "35%", // Moved up (was 40%)
         transform: "translateY(-50%)",
         maxWidth: "320px",
         boxShadow: `0 2px 8px ${Colors.shop.primary}40`,
@@ -58,7 +47,7 @@ export const TutorialPopup: React.FC<TutorialPopupProps> = ({
       return {
         ...baseStyle,
         right: "375px", // Position further left to avoid overlap with evolution panel
-        top: "45%",
+        top: "35%", // Moved up (was 45%)
         transform: "translateY(-50%)",
         boxShadow: `0 2px 8px ${Colors.evolution.primary}40`,
         border: `2px solid ${Colors.evolution.primary}`,
@@ -69,165 +58,150 @@ export const TutorialPopup: React.FC<TutorialPopupProps> = ({
   };
 
   return (
-    <>
-      <div
-        style={getPopupStyle()}
-        onClick={onClose || undefined}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = "translateY(-50%) scale(1.01)";
-          e.currentTarget.style.background = "rgba(80, 80, 80, 0.95)";
-          const borderColor =
-            position === "shop"
-              ? Colors.shop.primary
-              : Colors.evolution.primary;
-          e.currentTarget.style.boxShadow = `0 4px 12px ${borderColor}60`;
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = "translateY(-50%) scale(1)";
-          e.currentTarget.style.background = "rgba(64, 64, 64, 0.9)";
-          const borderColor =
-            position === "shop"
-              ? Colors.shop.primary
-              : Colors.evolution.primary;
-          e.currentTarget.style.boxShadow = `0 2px 8px ${borderColor}40`;
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-          <span style={{ fontSize: "28px" }}>💡</span>
-          <div
-            style={{
-              opacity: 0.8,
-              lineHeight: "1.3",
-              fontSize: "15px",
-              whiteSpace: "pre-line",
-            }}
-          >
-            {message.split("\n").map((line, index) => (
-              <div
-                key={index}
-                style={{
-                  marginBottom:
-                    index === message.split("\n").length - 2 ? "12px" : "0px",
-                }}
-              >
-                {line.split(" ").map((word, wordIndex) => {
-                  // Handle punctuation by checking the word without trailing punctuation
-                  const cleanWord = word.replace(/[.,!?]$/, "");
+    <div
+      style={getPopupStyle()}
+      onClick={onClose || undefined}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = "translateY(-50%) scale(1.01)";
+        e.currentTarget.style.background = "rgba(80, 80, 80, 0.95)";
+        const borderColor =
+          position === "shop"
+            ? Colors.shop.primary
+            : Colors.evolution.primary;
+        e.currentTarget.style.boxShadow = `0 4px 12px ${borderColor}60`;
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = "translateY(-50%) scale(1)";
+        e.currentTarget.style.background = "rgba(64, 64, 64, 0.9)";
+        const borderColor =
+          position === "shop"
+            ? Colors.shop.primary
+            : Colors.evolution.primary;
+        e.currentTarget.style.boxShadow = `0 2px 8px ${borderColor}40`;
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <span style={{ fontSize: "28px" }}>💡</span>
+        <div
+          style={{
+            opacity: 0.8,
+            lineHeight: "1.3",
+            fontSize: "15px",
+            whiteSpace: "pre-line",
+          }}
+        >
+          {message.split("\n").map((line, index) => (
+            <div
+              key={index}
+              style={{
+                marginBottom:
+                  index === message.split("\n").length - 2 ? "12px" : "0px",
+              }}
+            >
+              {line.split(" ").map((word, wordIndex) => {
+                // Handle punctuation by checking the word without trailing punctuation
+                const cleanWord = word.replace(/[.,!?]$/, "");
 
-                  if (cleanWord === "Generators") {
-                    return (
-                      <span
-                        key={wordIndex}
-                        style={{
-                          fontWeight: "bold",
-                          color: Colors.generators.primary,
-                        }}
-                      >
-                        {word}{" "}
-                      </span>
-                    );
-                  }
-                  if (cleanWord === "Evolution" || cleanWord === "Evolutions") {
-                    return (
-                      <span
-                        key={wordIndex}
-                        style={{
-                          fontWeight: "bold",
-                          color: Colors.evolution.primary,
-                        }}
-                      >
-                        {word}{" "}
-                      </span>
-                    );
-                  }
-                  if (cleanWord === "Levels") {
-                    return (
-                      <span
-                        key={wordIndex}
-                        style={{
-                          fontWeight: "bold",
-                          color: Colors.evolution.primary,
-                        }}
-                      >
-                        {word}{" "}
-                      </span>
-                    );
-                  }
-                  if (cleanWord === "Upgrades") {
-                    return (
-                      <span
-                        key={wordIndex}
-                        style={{
-                          fontWeight: "bold",
-                          color: Colors.upgrades.light,
-                        }}
-                      >
-                        {word}{" "}
-                      </span>
-                    );
-                  }
-                  if (cleanWord === "Biomass") {
-                    return (
-                      <span
-                        key={wordIndex}
-                        style={{
-                          fontWeight: "bold",
-                          color: Colors.biomass.primary,
-                        }}
-                      >
-                        {word}{" "}
-                      </span>
-                    );
-                  }
+                if (cleanWord === "Generators") {
+                  return (
+                    <span
+                      key={wordIndex}
+                      style={{
+                        fontWeight: "bold",
+                        color: Colors.generators.primary,
+                      }}
+                    >
+                      {word}{" "}
+                    </span>
+                  );
+                }
+                if (cleanWord === "Evolution" || cleanWord === "Evolutions") {
+                  return (
+                    <span
+                      key={wordIndex}
+                      style={{
+                        fontWeight: "bold",
+                        color: Colors.evolution.primary,
+                      }}
+                    >
+                      {word}{" "}
+                    </span>
+                  );
+                }
+                if (cleanWord === "Levels") {
+                  return (
+                    <span
+                      key={wordIndex}
+                      style={{
+                        fontWeight: "bold",
+                        color: Colors.evolution.primary,
+                      }}
+                    >
+                      {word}{" "}
+                    </span>
+                  );
+                }
+                if (cleanWord === "Upgrades") {
+                  return (
+                    <span
+                      key={wordIndex}
+                      style={{
+                        fontWeight: "bold",
+                        color: Colors.upgrades.light,
+                      }}
+                    >
+                      {word}{" "}
+                    </span>
+                  );
+                }
+                if (cleanWord === "Biomass") {
+                  return (
+                    <span
+                      key={wordIndex}
+                      style={{
+                        fontWeight: "bold",
+                        color: Colors.biomass.primary,
+                      }}
+                    >
+                      {word}{" "}
+                    </span>
+                  );
+                }
 
-                  // Special handling for "How far can you go?" phrase
-                  if (line.includes("How far can you go?")) {
-                    const phraseStart = line.indexOf("How far can you go?");
-                    const phraseEnd =
-                      phraseStart + "How far can you go?".length;
-                    const wordStart = line.indexOf(word);
+                // Special handling for "How far can you go?" phrase
+                if (line.includes("How far can you go?")) {
+                  const phraseStart = line.indexOf("How far can you go?");
+                  const phraseEnd =
+                    phraseStart + "How far can you go?".length;
+                  const wordStart = line.indexOf(word);
 
-                    if (wordStart >= phraseStart && wordStart < phraseEnd) {
-                      return (
-                        <span key={wordIndex} style={{ fontWeight: "bold" }}>
-                          {word}{" "}
-                        </span>
-                      );
-                    }
-                  }
-                  if (cleanWord === "Shop") {
+                  if (wordStart >= phraseStart && wordStart < phraseEnd) {
                     return (
-                      <span
-                        key={wordIndex}
-                        style={{
-                          fontWeight: "bold",
-                          color: Colors.shop.primary,
-                        }}
-                      >
+                      <span key={wordIndex} style={{ fontWeight: "bold" }}>
                         {word}{" "}
                       </span>
                     );
                   }
-                  return word + " ";
-                })}
-              </div>
-            ))}
-          </div>
+                }
+                if (cleanWord === "Shop") {
+                  return (
+                    <span
+                      key={wordIndex}
+                      style={{
+                        fontWeight: "bold",
+                        color: Colors.shop.primary,
+                      }}
+                    >
+                      {word}{" "}
+                    </span>
+                  );
+                }
+                return word + " ";
+              })}
+            </div>
+          ))}
         </div>
       </div>
-
-      <style>{`
-        @keyframes popupExpand {
-          0% {
-            opacity: 0;
-            transform: translateY(-50%) scale(0.8);
-          }
-          100% {
-            opacity: 1;
-            transform: translateY(-50%) scale(1);
-          }
-        }
-      `}</style>
-    </>
+    </div>
   );
 };

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -56,6 +56,8 @@ export const Colors = {
     secondary: '#dc2626',  // Darker red for hover states
     light: '#f87171',      // Light red for subtle elements
     dark: '#b91c1c',       // Dark red for emphasis
+    darker: '#991b1b',     // Even darker red for unaffordable items
+    medium: '#d32f2f',     // Medium red for unaffordable items (between primary and darker)
   },
 
   // Neutral colors


### PR DESCRIPTION


- Increased shop panel width to 350px
- Added tutorial text following cursor with improved visibility
- Created slime trail effect for main game (50% more frequent, shorter duration)
- Updated shop items to use colored borders with gray backgrounds
- Fixed tutorial upgrade background colors (gray during click-blob, purple otherwise)
- Improved red text visibility for unaffordable items
- Reduced spacing between shop filters and divider